### PR TITLE
Update database connection string to remote server

### DIFF
--- a/src/HA_ERP.DbMigrator/appsettings.json
+++ b/src/HA_ERP.DbMigrator/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=HA_ERP;Trusted_Connection=True;TrustServerCertificate=True"
+    "Default": "Server=160.250.132.24;Database=ThaoAnhTestDb;User Id=sa;Password=ErpDb@2025;TrustServerCertificate=True;"
   },
   "OpenIddict": {
     "Applications": {

--- a/src/HA_ERP.HttpApi.Host/appsettings.json
+++ b/src/HA_ERP.HttpApi.Host/appsettings.json
@@ -6,7 +6,7 @@
     "RedirectAllowedUrls": "http://localhost:4200"
   },
   "ConnectionStrings": {
-    "Default": "Server=(LocalDb)\\MSSQLLocalDB;Database=HA_ERP;Trusted_Connection=True;TrustServerCertificate=True"
+    "Default": "Server=160.250.132.24;Database=ThaoAnhTestDb;User Id=sa;Password=ErpDb@2025;TrustServerCertificate=True;"
   },
   "AuthServer": {
     "Authority": "https://localhost:44335",


### PR DESCRIPTION
Replaced the local SQL Server connection string with a new one that connects to a remote SQL Server at 160.250.132.24. Updated credentials are now included for authentication.