### PR TITLE
Add permissions, entities, and services for Staffs/Organizations

### DIFF
--- a/src/HA_ERP.Application.Contracts/Organizations/CreateOrganizationDto.cs
+++ b/src/HA_ERP.Application.Contracts/Organizations/CreateOrganizationDto.cs
@@ -1,0 +1,21 @@
+﻿using HA_ERP.Organizstions;
+using HA_ERP.Staffs;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Organizations
+{
+    public class CreateOrganizationDto
+    {
+        [Required]
+        [StringLength(OrganizationConsts.MaxCodeLength)]
+        public string Code { get; set; }
+        [Required]
+        [StringLength(OrganizationConsts.MaxNameLength)]
+        public string Name { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Organizations/GetListOrganizationDto.cs
+++ b/src/HA_ERP.Application.Contracts/Organizations/GetListOrganizationDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Organizations
+{
+    public class GetListOrganizationDto : PagedAndSortedResultRequestDto
+    {
+        public string? Filter { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Organizations/IOrganizationAppService.cs
+++ b/src/HA_ERP.Application.Contracts/Organizations/IOrganizationAppService.cs
@@ -1,0 +1,24 @@
+﻿using HA_ERP.Staffs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Application.Services;
+
+namespace HA_ERP.Organizations
+{
+    public interface IOrganizationAppService : IApplicationService
+    {
+        Task<CreateOrganizationDto> GetAsync(int id);
+
+        Task<PagedResultDto<OrganizationDto>> GetListAsync(GetStaffListDto input);
+
+        Task<OrganizationDto> CreateAsync(CreateOrganizationDto input);
+
+        Task UpdateAsync(int id, UpdateOrganizationDto input);
+
+        Task DeleteAsync(int id);
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Organizations/OrganizationDto.cs
+++ b/src/HA_ERP.Application.Contracts/Organizations/OrganizationDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Organizations
+{
+    public class OrganizationDto : EntityDto<int>
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Organizations/UpdateOrganizationDto.cs
+++ b/src/HA_ERP.Application.Contracts/Organizations/UpdateOrganizationDto.cs
@@ -1,0 +1,20 @@
+﻿using HA_ERP.Organizstions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Organizations
+{
+    public class UpdateOrganizationDto
+    {
+        [Required]
+        [StringLength(OrganizationConsts.MaxCodeLength)]
+        public string Code { get; set; }
+        [Required]
+        [StringLength(OrganizationConsts.MaxNameLength)]
+        public string Name { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Permissions/HA_ERPPermissionDefinitionProvider.cs
+++ b/src/HA_ERP.Application.Contracts/Permissions/HA_ERPPermissionDefinitionProvider.cs
@@ -11,6 +11,19 @@ public class HA_ERPPermissionDefinitionProvider : PermissionDefinitionProvider
         var myGroup = context.AddGroup(HA_ERPPermissions.GroupName);
         //Define your own permissions here. Example:
         //myGroup.AddPermission(HA_ERPPermissions.MyPermission1, L("Permission:MyPermission1"));
+
+        var organizationsPermission = myGroup.AddPermission(HA_ERPPermissions.Organizations.Default, L("Permission:Organizations"));
+        organizationsPermission.AddChild(HA_ERPPermissions.Organizations.Create, L("Permission:Organizations.Create"));
+        organizationsPermission.AddChild(HA_ERPPermissions.Organizations.Update, L("Permission:Organizations.Update"));
+        organizationsPermission.AddChild(HA_ERPPermissions.Organizations.Delete, L("Permission:Organizations.Delete"));
+
+        var staffsPermission = myGroup.AddPermission(HA_ERPPermissions.Staffs.Default, L("Permission:Staffs"));
+        staffsPermission.AddChild(HA_ERPPermissions.Staffs.Create, L("Permission:Staffs.Create"));
+        staffsPermission.AddChild(HA_ERPPermissions.Staffs.Update, L("Permission:Staffs.Update"));
+        staffsPermission.AddChild(HA_ERPPermissions.Staffs.Delete, L("Permission:Staffs.Delete"));
+
+
+
     }
 
     private static LocalizableString L(string name)

--- a/src/HA_ERP.Application.Contracts/Permissions/HA_ERPPermissions.cs
+++ b/src/HA_ERP.Application.Contracts/Permissions/HA_ERPPermissions.cs
@@ -6,4 +6,25 @@ public static class HA_ERPPermissions
 
     //Add your own permission names. Example:
     //public const string MyPermission1 = GroupName + ".MyPermission1";
+
+
+    public static class Staffs
+    {
+        public const string Default = GroupName + ".Staffs";
+        public const string Create = Default + ".Create";
+        public const string Update = Default + ".Update";
+        public const string Delete = Default + ".Delete";
+        public const string View = Default + ".View";
+    }
+
+    public static class Organizations
+    {
+        public const string Default = GroupName + ".Organizations";
+        public const string Create = Default + ".Create";
+        public const string Update = Default + ".Update";
+        public const string Delete = Default + ".Delete";
+        public const string View = Default + ".View";
+    }
+
+
 }

--- a/src/HA_ERP.Application.Contracts/Staffs/CreateStaffDto.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/CreateStaffDto.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Staffs
+{
+    public class CreateStaffDto
+    {
+        [Required]
+        public int OrganizationId { get; set; }
+        public int ManagedId { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxCodeLength)]
+        public string Code { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxNameLength)]
+        public string Name { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxMobileLength)]
+        public string Mobile { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxEmailLength)]
+        public string Email { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxAddressLength)]
+        public string Address { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAccountNameLength)]
+        public string BankAccountName { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAccountNoLength)]
+        public string BankAccountNo { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankNameLength)]
+        public string BankName { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAddressLength)]
+        public string BankAddress { get; set; }
+
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Staffs/GetStaffListDto.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/GetStaffListDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Staffs
+{
+    public class GetStaffListDto : PagedAndSortedResultRequestDto
+    {
+        public string? Filter { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Staffs/IStaffAppService.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/IStaffAppService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.Application.Services;
+
+namespace HA_ERP.Staffs
+{
+    public interface IStaffAppService : IApplicationService
+    {
+        Task<StaffDto> GetAsync(int id);
+
+        Task<PagedResultDto<StaffDto>> GetListAsync(GetStaffListDto input);
+
+        Task<StaffDto> CreateAsync(CreateStaffDto input);
+
+        Task UpdateAsync(int id, UpdateStaffDto input);
+
+        Task DeleteAsync(int id);
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Staffs/StaffDto.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/StaffDto.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Staffs
+{
+    public class StaffDto : AuditedEntityDto<int>
+    {
+        public int OrganizationId { get; set; }
+        public int ManagedId { get; set; }
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public string Mobile { get; set; }
+        public string Email { get; set; }
+        public string Address { get; set; }
+        public string BankAccountName { get; set; }
+        public string BankAccountNo { get; set; }
+        public string BankName { get; set; }
+        public string BankAddress { get; set; }
+    }
+}

--- a/src/HA_ERP.Application.Contracts/Staffs/UpdateStaffDto.cs
+++ b/src/HA_ERP.Application.Contracts/Staffs/UpdateStaffDto.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Staffs
+{
+    public class UpdateStaffDto
+    {
+        [Required]
+        public int OrganizationId { get; set; }
+        public int ManagedId { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxCodeLength)]
+        public string Code { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxNameLength)]
+        public string Name { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxMobileLength)]
+        public string Mobile { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxEmailLength)]
+        public string Email { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxAddressLength)]
+        public string Address { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAccountNameLength)]
+        public string BankAccountName { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAccountNoLength)]
+        public string BankAccountNo { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankNameLength)]
+        public string BankName { get; set; }
+        [Required]
+        [StringLength(StaffConsts.MaxBankAddressLength)]
+        public string BankAddress { get; set; }
+    }
+}

--- a/src/HA_ERP.Application/HA_ERPApplicationAutoMapperProfile.cs
+++ b/src/HA_ERP.Application/HA_ERPApplicationAutoMapperProfile.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using HA_ERP.Organizations;
+using HA_ERP.Staffs;
 
 namespace HA_ERP;
 
@@ -9,5 +11,8 @@ public class HA_ERPApplicationAutoMapperProfile : Profile
         /* You can configure your AutoMapper mapping configuration here.
          * Alternatively, you can split your mapping configurations
          * into multiple profile classes for a better organization. */
+
+        CreateMap<Staff, StaffDto>();
+        CreateMap<Organization, OrganizationDto>();
     }
 }

--- a/src/HA_ERP.Application/Organizations/OrganizationAppService.cs
+++ b/src/HA_ERP.Application/Organizations/OrganizationAppService.cs
@@ -1,0 +1,53 @@
+﻿using HA_ERP.Permissions;
+using HA_ERP.Staffs;
+using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Organizations
+{
+    [Authorize(HA_ERPPermissions.Organizations.Default)]
+    public class OrganizationAppService : HA_ERPAppService, IOrganizationAppService
+    {
+        private readonly IOrganizationRepository _organizationRepository;
+        private readonly OrganizationManager _organizationManager;
+
+        public OrganizationAppService(IOrganizationRepository organizationRepository, OrganizationManager organizationManager)
+        {
+            _organizationRepository = organizationRepository;
+            _organizationManager = organizationManager;
+        }
+
+        [Authorize(HA_ERPPermissions.Organizations.Create)]
+        public Task<OrganizationDto> CreateAsync(CreateOrganizationDto input)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Authorize(HA_ERPPermissions.Organizations.Delete)]
+        public Task DeleteAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<CreateOrganizationDto> GetAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PagedResultDto<OrganizationDto>> GetListAsync(GetStaffListDto input)
+        {
+            throw new NotImplementedException();
+        }
+        [Authorize(HA_ERPPermissions.Organizations.Update)]
+
+        public Task UpdateAsync(int id, UpdateOrganizationDto input)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/HA_ERP.Application/Staffs/StaffAppService.cs
+++ b/src/HA_ERP.Application/Staffs/StaffAppService.cs
@@ -1,0 +1,52 @@
+﻿using HA_ERP.Organizations;
+using HA_ERP.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Dtos;
+
+namespace HA_ERP.Staffs
+{
+    [Authorize(HA_ERPPermissions.Staffs.Default)]
+    public class StaffAppService : HA_ERPAppService, IStaffAppService
+    {
+        private readonly IOrganizationAppService _organizationAppService;
+
+        private readonly IStaffRepository _staffRepository;
+
+        public StaffAppService(IOrganizationAppService organizationAppService, IStaffRepository staffRepository)
+        {
+            _organizationAppService = organizationAppService;
+            _staffRepository = staffRepository;
+        }
+        [Authorize(HA_ERPPermissions.Staffs.Create)]
+        public Task<StaffDto> CreateAsync(CreateStaffDto input)
+        {
+            throw new NotImplementedException();
+        }
+        [Authorize(HA_ERPPermissions.Staffs.Delete)]
+        public Task DeleteAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<StaffDto> GetAsync(int id)
+        {
+            throw new NotImplementedException();
+        }
+        public Task<PagedResultDto<StaffDto>> GetListAsync(GetStaffListDto input)
+        {
+            throw new NotImplementedException();
+        }
+        [Authorize(HA_ERPPermissions.Staffs.Update)]
+
+        public Task UpdateAsync(int id, UpdateStaffDto input)
+        {
+            throw new NotImplementedException();
+        }
+ 
+    }
+}

--- a/src/HA_ERP.Domain.Shared/Localization/HA_ERP/en.json
+++ b/src/HA_ERP.Domain.Shared/Localization/HA_ERP/en.json
@@ -4,6 +4,26 @@
     "AppName": "HA_ERP",
     "Menu:Home": "Home",
     "Welcome": "Welcome",
-    "LongWelcomeMessage": "Welcome to the application. This is a startup project based on the ABP framework. For more information, visit abp.io."
+    "LongWelcomeMessage": "Welcome to the application. This is a startup project based on the ABP framework. For more information, visit abp.io.",
+
+    "Permission:Staffs": "Staffs Management",
+    "Permission:Staffs.Create": "Creating new Staffs",
+    "Permission:Staffs.Edit": "Editing the Staffs",
+    "Permission:Staffs.Delete": "Deleting the Staffs",
+
+    "Permission:Organizations": "Organizations Management",
+    "Permission:Organizations.Create": "Creating new Organizations",
+    "Permission:Organizations.Edit": "Editing the Organizations",
+    "Permission:Organizations.Delete": "Deleting the Organizations"
+
+
   }
+
+
+
+
+
+
+
+
 }

--- a/src/HA_ERP.Domain.Shared/Organizations/OrganizationConsts.cs
+++ b/src/HA_ERP.Domain.Shared/Organizations/OrganizationConsts.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Organizstions
+{
+    public static class OrganizationConsts
+    {
+        public const int MaxNameLength = 36;
+        public const int MaxCodeLength = 12;
+    }
+}

--- a/src/HA_ERP.Domain.Shared/Staffs/StaffConsts.cs
+++ b/src/HA_ERP.Domain.Shared/Staffs/StaffConsts.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HA_ERP.Staffs
+{
+     public static class StaffConsts
+    {
+        public const int MaxNameLength = 36;
+        public const int MaxCodeLength = 12;
+        public const int MaxMobileLength = 12;
+        public const int MaxEmailLength = 36;
+        public const int MaxAddressLength = 100;
+        public const int MaxBankAccountNameLength = 150;
+        public const int MaxBankAccountNoLength = 36;
+        public const int MaxBankNameLength = 100;
+        public const int MaxBankAddressLength = 150;
+    }
+}

--- a/src/HA_ERP.Domain/Organizations/IOrganizationRepository.cs
+++ b/src/HA_ERP.Domain/Organizations/IOrganizationRepository.cs
@@ -1,0 +1,14 @@
+﻿using HA_ERP.Staffs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories;
+
+namespace HA_ERP.Organizations
+{
+    public interface IOrganizationRepository : IRepository<Organization, int>
+    {
+    }
+}

--- a/src/HA_ERP.Domain/Organizations/Organization.cs
+++ b/src/HA_ERP.Domain/Organizations/Organization.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace HA_ERP.Organizations
+{
+    public class Organization : FullAuditedAggregateRoot<int>
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+
+        public Organization()
+        {
+            
+        }
+
+        public Organization(int id, string code, string name) : base(id)
+        {
+            Code = code;
+            Name = name;
+        }
+    }
+}

--- a/src/HA_ERP.Domain/Organizations/OrganizationManager.cs
+++ b/src/HA_ERP.Domain/Organizations/OrganizationManager.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Services;
+
+namespace HA_ERP.Organizations
+{
+    public class OrganizationManager : DomainService
+    {
+        private readonly IOrganizationRepository  _organizationRepository;
+
+        public OrganizationManager(IOrganizationRepository organizationRepository)
+        {
+            _organizationRepository = organizationRepository;
+        }
+    }
+}

--- a/src/HA_ERP.Domain/Staffs/IStaffRepository.cs
+++ b/src/HA_ERP.Domain/Staffs/IStaffRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories;
+
+namespace HA_ERP.Staffs
+{
+    public interface IStaffRepository : IRepository<Staff, int>
+    {
+    }
+}

--- a/src/HA_ERP.Domain/Staffs/Staff.cs
+++ b/src/HA_ERP.Domain/Staffs/Staff.cs
@@ -1,0 +1,48 @@
+﻿using HA_ERP.Organizations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace HA_ERP.Staffs
+{
+    public class Staff : FullAuditedAggregateRoot<int>
+    {
+        public int OrganizationId { get; set; }
+        public int ManagerId { get; set; }
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public string Mobile { get; set; }
+        public string Email { get; set; }
+        public string Address { get; set; }
+        public string BankAccountName { get; set; }
+        public string BankAccountNo { get; set; }
+        public string BankName { get; set; }
+        public string BankAddress { get; set; }
+
+        private Staff()
+        {
+            
+        }
+
+        public Staff(int organizationId, int managerId, string code, string name, string mobile, string email, string address, string bankAccountName, string bankAccountNo, string bankName, string bankAddress)
+        {
+            OrganizationId = organizationId;
+            ManagerId = managerId;
+            Code = code;
+            Name = name;
+            Mobile = mobile;
+            Email = email;
+            Address = address;
+            BankAccountName = bankAccountName;
+            BankAccountNo = bankAccountNo;
+            BankName = bankName;
+            BankAddress = bankAddress;
+            
+        }
+    }
+   
+
+}

--- a/src/HA_ERP.Domain/Staffs/StaffManager.cs
+++ b/src/HA_ERP.Domain/Staffs/StaffManager.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Services;
+
+namespace HA_ERP.Staffs
+{
+    public class StaffManager : DomainService
+    {
+        private readonly IStaffRepository _staffRepository;
+
+        public StaffManager(IStaffRepository staffRepository)
+        {
+            _staffRepository = staffRepository;
+        }
+
+    }
+}

--- a/src/HA_ERP.EntityFrameworkCore/EntityFrameworkCore/HA_ERPDbContext.cs
+++ b/src/HA_ERP.EntityFrameworkCore/EntityFrameworkCore/HA_ERPDbContext.cs
@@ -12,7 +12,9 @@ using Volo.Abp.PermissionManagement.EntityFrameworkCore;
 using Volo.Abp.SettingManagement.EntityFrameworkCore;
 using Volo.Abp.TenantManagement;
 using Volo.Abp.TenantManagement.EntityFrameworkCore;
-
+using HA_ERP.Staffs;
+using HA_ERP.Organizations;
+using Volo.Abp.EntityFrameworkCore.Modeling;
 namespace HA_ERP.EntityFrameworkCore;
 
 [ReplaceDbContext(typeof(IIdentityDbContext))]
@@ -51,7 +53,17 @@ public class HA_ERPDbContext :
     public DbSet<Tenant> Tenants { get; set; }
     public DbSet<TenantConnectionString> TenantConnectionStrings { get; set; }
 
+    //app dbsets
+    public DbSet<Staff> Staffs { get; set; }
+    public DbSet<Organization> Organizations { get; set; }
+
     #endregion
+
+
+
+
+
+
 
     public HA_ERPDbContext(DbContextOptions<HA_ERPDbContext> options)
         : base(options)
@@ -82,5 +94,44 @@ public class HA_ERPDbContext :
         //    b.ConfigureByConvention(); //auto configure for the base class props
         //    //...
         //});
+
+        builder.Entity<Staff>(b =>
+        {
+            b.ToTable(HA_ERPConsts.DbTablePrefix + "Staffs", HA_ERPConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.Code).IsRequired().HasMaxLength(12); //temp (EMP*********)
+            b.Property(x => x.Name).IsRequired().HasMaxLength(36);
+            b.Property(x => x.Mobile).IsRequired().HasMaxLength(12);
+            b.Property(x => x.Email).IsRequired().HasMaxLength(100);
+            b.Property(x => x.Address).HasMaxLength(150);
+            b.Property(x => x.BankAccountName).HasMaxLength(36);
+            b.Property(x => x.BankAccountNo).HasMaxLength(36);
+            b.Property(x => x.BankName).HasMaxLength(100);
+            b.Property(x => x.BankAddress).HasMaxLength(150);
+            b.HasIndex(x => x.Code).IsUnique();
+            b.HasIndex(x => x.Email).IsUnique();
+            b.HasIndex(x => x.Mobile).IsUnique();
+            b.HasOne<Organization>()
+                .WithMany()
+                .HasForeignKey(x => x.OrganizationId)
+                .IsRequired();
+            b.HasOne<Staff>()
+                .WithMany()
+                .HasForeignKey(x => x.ManagerId)
+                .IsRequired(false)
+                .OnDelete(DeleteBehavior.Restrict); //optional, can be null
+
+
+        });
+
+        builder.Entity<Organization>(b =>
+        {
+            b.ToTable(HA_ERPConsts.DbTablePrefix + "Organizations", HA_ERPConsts.DbSchema);
+            b.ConfigureByConvention();
+            b.Property(x => x.Code).IsRequired().HasMaxLength(6); //temp (ORG***)
+            b.Property(x => x.Name).IsRequired().HasMaxLength(50);
+
+        });
+
     }
 }

--- a/src/HA_ERP.EntityFrameworkCore/Migrations/20250618164513_Fix_Staff_Self_Reference_v2.Designer.cs
+++ b/src/HA_ERP.EntityFrameworkCore/Migrations/20250618164513_Fix_Staff_Self_Reference_v2.Designer.cs
@@ -4,6 +4,7 @@ using HA_ERP.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace HA_ERP.Migrations
 {
     [DbContext(typeof(HA_ERPDbContext))]
-    partial class HA_ERPDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250618164513_Fix_Staff_Self_Reference_v2")]
+    partial class Fix_Staff_Self_Reference_v2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/HA_ERP.EntityFrameworkCore/Migrations/20250618164513_Fix_Staff_Self_Reference_v2.cs
+++ b/src/HA_ERP.EntityFrameworkCore/Migrations/20250618164513_Fix_Staff_Self_Reference_v2.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HA_ERP.Migrations
+{
+    /// <inheritdoc />
+    public partial class Fix_Staff_Self_Reference_v2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppOrganizations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Code = table.Column<string>(type: "nvarchar(6)", maxLength: 6, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppOrganizations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AppStaffs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    OrganizationId = table.Column<int>(type: "int", nullable: false),
+                    ManagerId = table.Column<int>(type: "int", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(12)", maxLength: 12, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                    Mobile = table.Column<string>(type: "nvarchar(12)", maxLength: 12, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Address = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    BankAccountName = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                    BankAccountNo = table.Column<string>(type: "nvarchar(36)", maxLength: 36, nullable: false),
+                    BankName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    BankAddress = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppStaffs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppStaffs_AppOrganizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "AppOrganizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AppStaffs_AppStaffs_ManagerId",
+                        column: x => x.ManagerId,
+                        principalTable: "AppStaffs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppStaffs_Code",
+                table: "AppStaffs",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppStaffs_Email",
+                table: "AppStaffs",
+                column: "Email",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppStaffs_ManagerId",
+                table: "AppStaffs",
+                column: "ManagerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppStaffs_Mobile",
+                table: "AppStaffs",
+                column: "Mobile",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppStaffs_OrganizationId",
+                table: "AppStaffs",
+                column: "OrganizationId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppStaffs");
+
+            migrationBuilder.DropTable(
+                name: "AppOrganizations");
+        }
+    }
+}

--- a/src/HA_ERP.EntityFrameworkCore/Organizations/EfCoreOrganizationRepository.cs
+++ b/src/HA_ERP.EntityFrameworkCore/Organizations/EfCoreOrganizationRepository.cs
@@ -1,0 +1,24 @@
+﻿using HA_ERP.EntityFrameworkCore;
+using HA_ERP.Staffs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace HA_ERP.Organizations
+{
+    public class EfCoreOrganizationRepository : EfCoreRepository<HA_ERPDbContext, Organization, int>,
+         IOrganizationRepository
+    {
+        public EfCoreOrganizationRepository(IDbContextProvider<HA_ERPDbContext> dbContextProvider) : base(dbContextProvider)
+        {
+        }
+
+    }
+}

--- a/src/HA_ERP.EntityFrameworkCore/Staffs/EfCoreStaffRepository.cs
+++ b/src/HA_ERP.EntityFrameworkCore/Staffs/EfCoreStaffRepository.cs
@@ -1,0 +1,22 @@
+﻿using HA_ERP.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace HA_ERP.Staffs
+{
+    public class EfCoreStaffRepository : EfCoreRepository<HA_ERPDbContext, Staff, int>,
+        IStaffRepository
+    {
+        public EfCoreStaffRepository(IDbContextProvider<HA_ERPDbContext> dbContextProvider) : base(dbContextProvider)
+        {
+        }
+
+   
+    }
+}


### PR DESCRIPTION
- Updated `HA_ERPPermissionDefinitionProvider` to define new permissions for "Organizations" and "Staffs".
- Modified `HA_ERPPermissions` to include static classes for permissions.
- Added mapping configurations in `HA_ERPApplicationAutoMapperProfile` for `Staff` and `Organization`.
- Updated `en.json` for new localization texts related to permissions.
- Enhanced `HA_ERPDbContext` with `DbSet` properties and entity configurations for `Staff` and `Organization`.
- Created new DTOs for data transfer and implemented CRUD services for organizations and staffs.
- Added constants classes for property length definitions.
- Established repository interfaces and implementations for data access.
- Defined `Organization` and `Staff` entity classes.
- Created migration class to set up database schema for new tables.